### PR TITLE
Fix 1.0 syntax in marginal damage files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ notifications:
   email: false
 before_install:
   - julia -e 'using Pkg; Pkg.add("Distributions")'
+  - julia -e 'using Pkg; Pkg.add("CSVFiles")'
+  - julia -e 'using Pkg; Pkg.add("DataFrames")'
+
   - julia -e 'using Pkg; Pkg.add("Mimi")'
 script:
   - julia test/runtests.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - julia -e 'using Pkg; Pkg.add("Distributions")'
   - julia -e 'using Pkg; Pkg.add("CSVFiles")'
   - julia -e 'using Pkg; Pkg.add("DataFrames")'
+  - julia -e 'using Pkg; Pkg.add("StatsBase")'
 
   - julia -e 'using Pkg; Pkg.add("Mimi")'
 script:

--- a/src/ClimateCO2CycleComponent.jl
+++ b/src/ClimateCO2CycleComponent.jl
@@ -11,7 +11,7 @@
     globc = Variable(index=[time])
 
     # Carbon boxes
-    cbox = Variable(index=[time,cpools])
+    cbox = Variable(index=[time,5])
 
     # Initial carbon box 1
     cbox10 = Parameter()

--- a/src/EmissionsComponent.jl
+++ b/src/EmissionsComponent.jl
@@ -101,11 +101,6 @@
                 v.ch4red[t, r] = 0
                 v.n2ored[t, r] = 0
                 v.mitigationcost[t, r] = 0
-
-                v.mco2[t] = 0
-                v.globch4[t] = 0
-                v.globn2o[t] = 0
-                v.globsf6[t] = 0
             end
 
             v.globknow[t] = 1

--- a/src/EmissionsComponent.jl
+++ b/src/EmissionsComponent.jl
@@ -101,6 +101,11 @@
                 v.ch4red[t, r] = 0
                 v.n2ored[t, r] = 0
                 v.mitigationcost[t, r] = 0
+
+                v.mco2[t] = 0
+                v.globch4[t] = 0
+                v.globn2o[t] = 0
+                v.globsf6[t] = 0
             end
 
             v.globknow[t] = 1

--- a/src/fund.jl
+++ b/src/fund.jl
@@ -67,7 +67,6 @@ function getfund(; nsteps = default_nsteps, datadir = default_datadir, params = 
 
     set_dimension!(m, :time, collect(1950:1950+nsteps))
     set_dimension!(m, :regions, ["USA", "CAN", "WEU", "JPK", "ANZ", "EEU", "FSU", "MDE", "CAM", "LAM", "SAS", "SEA", "CHI", "MAF", "SSA", "SIS"])
-    set_dimension!(m, :cpools, 1:5)
     # ---------------------------------------------
     # Create components
     # ---------------------------------------------

--- a/src/marginaldamage3.jl
+++ b/src/marginaldamage3.jl
@@ -1,6 +1,6 @@
-include("../helper.jl")
-include("../fund.jl")
-using Fund 
+include("helper.jl")
+include("fund.jl")
+using .Fund 
 
 """
 Returns one default FUND model and one model with additional emissions of the specified gas in the specified year.
@@ -12,9 +12,9 @@ function getmarginalmodels(; gas = :C, emissionyear = 2010, parameters = nothing
 
     # Get model to add marginal emissions to
     m2 = getfund(nsteps = yearstorun, params = parameters)
-    add_comp!(m2, adder, :marginalemission, before = :climateco2cycle)
+    add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle)
     addem = zeros(yearstorun + 1)
-    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] = 1.0
+    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] .= 1.0
     set_param!(m2, :marginalemission, :add, addem)
 
     # Reconnect the appropriate emissions in the marginal model

--- a/src/marginaldamage3.jl
+++ b/src/marginaldamage3.jl
@@ -14,7 +14,7 @@ function getmarginalmodels(; gas = :C, emissionyear = 2010, parameters = nothing
     m2 = getfund(nsteps = yearstorun, params = parameters)
     add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle, first = 1951)
     addem = zeros(yearstorun)
-    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] .= 1.0
+    addem[getindexfromyear(emissionyear)-1:getindexfromyear(emissionyear) + 8] .= 1.0
     set_param!(m2, :marginalemission, :add, addem)
 
     # Reconnect the appropriate emissions in the marginal model

--- a/src/marginaldamages.jl
+++ b/src/marginaldamages.jl
@@ -1,3 +1,4 @@
+using Mimi 
 include("helper.jl")
 include("fund.jl")
 using .Fund 
@@ -15,15 +16,16 @@ function getmarginaldamages(; emissionyear=2010, parameters = nothing, yearstoag
 
     # Get model to add marginal emissions to
     m2 = getfund(nsteps = yearstorun, params = parameters)
-    add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle)
-    addem = zeros(yearstorun + 1)
-    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] .= 1.0
+    add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle, first = 1951)
+    addem = zeros(yearstorun)
+    addem[getindexfromyear(emissionyear)-1:getindexfromyear(emissionyear) + 8] .= 1.0
     set_param!(m2, :marginalemission, :add, addem)
 
     # Reconnect the appropriate emissions in the marginal model
     if gas == :C
         connect_param!(m2, :marginalemission, :input, :emissions, :mco2)
-        connect_param!(m2, :climateco2cycle, :mco2, :marginalemission, :output)
+        # connect_param!(m2, :climateco2cycle, :mco2, :marginalemission, :output, zeros(yearstorun + 1))
+        connect_param!(m2, :climateco2cycle, :mco2, :marginalemission, :output, repeat([missing], yearstorun + 1))
     elseif gas == :CH4
         connect_param!(m2, :marginalemission, :input, :emissions, :globch4)
         connect_param!(m2, :climatech4cycle, :globch4, :marginalemission, :output)

--- a/src/marginaldamages.jl
+++ b/src/marginaldamages.jl
@@ -1,6 +1,6 @@
-include("../helper.jl")
-include("../fund.jl")
-using Fund 
+include("helper.jl")
+include("fund.jl")
+using .Fund 
 
 """
 Returns a matrix of marginal damages per one ton of additional emissions of the specified gas in the specified year.
@@ -15,9 +15,9 @@ function getmarginaldamages(; emissionyear=2010, parameters = nothing, yearstoag
 
     # Get model to add marginal emissions to
     m2 = getfund(nsteps = yearstorun, params = parameters)
-    add_comp!(m2, adder, :marginalemission, before = :climateco2cycle)
+    add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle)
     addem = zeros(yearstorun + 1)
-    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] = 1.0
+    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] .= 1.0
     set_param!(m2, :marginalemission, :add, addem)
 
     # Reconnect the appropriate emissions in the marginal model

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -2,7 +2,7 @@ using Mimi
 
 include("helper.jl")
 include("fund.jl")
-using Fund 
+using .Fund 
 
 
 """
@@ -18,9 +18,9 @@ function create_marginal_FUND_model(; gas = :C, emissionyear = 2010, parameters 
     m1, m2 = mm.base, mm.marginal
 
     # Add additional emissions to m2
-    add_comp!(m2, adder, :marginalemission, before = :climateco2cycle)
+    add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle)
     addem = zeros(yearstorun + 1)
-    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] = 1.0
+    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] .= 1.0
     set_param!(m2, :marginalemission, :add, addem)
 
     # Reconnect the appropriate emissions in m2

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -20,7 +20,7 @@ function create_marginal_FUND_model(; gas = :C, emissionyear = 2010, parameters 
     # Add additional emissions to m2
     add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle, first = 1951)
     addem = zeros(yearstorun)
-    addem[getindexfromyear(emissionyear):getindexfromyear(emissionyear) + 9] .= 1.0
+    addem[getindexfromyear(emissionyear)-1:getindexfromyear(emissionyear) + 8] .= 1.0
     set_param!(m2, :marginalemission, :add, addem)
 
     # Reconnect the appropriate emissions in m2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,22 +63,9 @@ for c in map(name, Mimi.compdefs(m)), v in Mimi.variable_names(m, c)
     else
         validation_results = convert(Array, df)
 
-        #some values have been purposefully changed from missing to zero:
-
-        # because of a recent update we added to Mimi, that doesn't allow other 
-        # components to access missing values. This was causing a problem within 
-        # the marginal damages functions, because the adder component's input 
-        # parameter is connected to one of the global gas variables in the emissions 
-        # component, which previously had missing values in the first timestep.
-        zeroparams = [:mco2, :globch4, :globn2o, :globsf6]
-        if c == :emissions && (v in zeroparams)
-            validation_results[1] = 0.0
-        end
-
-        #remove NaNs and Missings
+        #remove NaNs
         results[ismissing.(results)] .= nullvalue
         results[isnan.(results)] .= nullvalue
-        validation_results[ismissing.(validation_results)] .= nullvalue
         validation_results[isnan.(validation_results)] .= nullvalue
 
         #match dimensions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,6 +79,25 @@ end
 
 end #fund-integration testset
 
+#------------------------------------------------------------------------------
+# 3. Test marginal damages functions (test that each function does not error)
+#------------------------------------------------------------------------------
+
+@testset "test-marginaldamages" begin 
+
+include("../src/marginaldamages.jl")
+md = getmarginaldamages()
+
+include("../src/marginaldamage3.jl")
+md3 = marginaldamage3()
+
+include("../src/new_marginaldamages.jl")
+scc = get_social_cost()
+md = getmarginaldamages()
+
+
+end #marginaldamages testset
+
 end #fund testset
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ using .Fund
 global m = getfund()
 run(m)
 
-nullvalue = -999.999
+missingvalue = -999.999
 err_number = 1.0e-9
 err_array = 0.0
 
@@ -63,10 +63,9 @@ for c in map(name, Mimi.compdefs(m)), v in Mimi.variable_names(m, c)
     else
         validation_results = convert(Array, df)
 
-        #remove NaNs
-        results[ismissing.(results)] .= nullvalue
-        results[isnan.(results)] .= nullvalue
-        validation_results[isnan.(validation_results)] .= nullvalue
+        #replace missings with missingvalue so they can be compared
+        results[ismissing.(results)] .= missingvalue
+        validation_results[ismissing.(validation_results)] .= missingvalue
 
         #match dimensions
         if size(validation_results,1) == 1


### PR DESCRIPTION
This PR includes:
- minor syntax fixes in the "marginaldamages.jl", "marginaldamage3.jl", and "new_marginaldamages.jl" files
- adds basic tests to runtests.jl to run each of these functions to make sure they don't error
- I had to add values to the emissions component variables in time 1, because of a recent update we added to Mimi, that doesn't allow other components to access `missing` values. This was causing a problem within the marginal damages functions, because the `adder` component's `input` parameter is connected to one of the global gas variables in the emissions component, which previously had `missing` values in the first timestep. This currently makes the validation tests fail, since now there is a zero value where it used to be missing. Let me know if this should be handled differently @davidanthoff 